### PR TITLE
Update mock and notebook

### DIFF
--- a/Notebook.ipynb
+++ b/Notebook.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "mock service dostępny będzie pod adresem `ws://mock:8025`\n",
     "\n",
-    "Skrypt należy uruchomić przed wykonaniem poniższej komórki, uruchomi on server websocketowy. Po uruchomieniu uruchamiamy komórkę i czekamy aż w skrypcie pojawi się informacja `Opened connection successfully!`. Skrypt wysyła kolejne porcje wiadomości po wciśnięciu ENTER\n",
+    "Skrypt należy uruchomić przed wykonaniem poniższej komórki, uruchomi on server websocketowy do którego nasze zapytanie się zasubskrybuje. Skrypt wysyła kolejne porcje wiadomości co 10 sekund\n",
     "\n",
     "W pierwszej serii polecą wiadomości o offsetach: 0s, 14s, 7s  \n",
     "W drugiej serii polecą wiadomości o offsetach: 15s, 8s, 21s  \n",


### PR DESCRIPTION
The mock is now quite straightforward. After running the mock one can see the output
```
docker run --rm --network="coin-net" --name mock -it barkingbad/ws-streamer:latest Mock.scala
Compiling project (Scala 3.0.2, JVM)
Compiled project (Scala 3.0.2, JVM)
Starting. Waiting for subscriptions...
```

When one will subscribe to our mock service, the following lines should be printed:
```
Opening connection...
Opened connection successfully!
Received message for subscription
Sending frames with T0+0s, T0+14s, T0+7s timestamps.
2021-11-01T12:00:00.123123Z - 181.67361174430897
2021-11-01T12:00:14.123123Z - 99.8755001157835
2021-11-01T12:00:07.123123Z - 134.34956787403817
Sending frames with T0+15s, T0+8s, T0+21s timestamps.
2021-11-01T12:00:15.123123Z - 640.5755260813921
2021-11-01T12:00:08.123123Z - 694.1934957506602
2021-11-01T12:00:21.123123Z - 491.90000117228095
Sending frames with T0+4s, T0+17s timestamps.
2021-11-01T12:00:04.123123Z - 229.89279117494766
2021-11-01T12:00:17.123123Z - 772.6514461421453
Conection has been closed.
```

![obraz](https://user-images.githubusercontent.com/32793002/140658721-aa3a5887-48f9-4c25-939b-ce5aa7033d32.png)
